### PR TITLE
Update bbop-rest-manager dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "bbop-graph-noctua": "0.0.35",
         "bbop-registry": "0.0.3",
         "bbop-response-barista": "0.0.9",
-        "bbop-rest-manager": "0.0.10",
+        "bbop-rest-manager": "0.0.18",
         "bbop-rest-response": "0.0.4",
         "class-expression": "0.0.11",
         "domino": "1.0.19",


### PR DESCRIPTION
Related to https://github.com/berkeleybop/bbop-rest-manager/pull/2

bbop-rest-manager has been updated, but this package still uses a very old version (0.10). There could be some (bad) side effect of GO that this package is not using the latest dependency (0.17 before the removal of sleep, 0.18 after). @kltm to check for possible conflits before merging this.